### PR TITLE
feat(ansible): Add base security playbooks

### DIFF
--- a/infrastructure/ansible/README.md
+++ b/infrastructure/ansible/README.md
@@ -1,0 +1,268 @@
+# Ansible Security Hardening Templates
+
+This directory contains comprehensive Ansible playbooks and roles for security hardening of Linux systems with a security-first approach.
+
+## Features
+
+### 🔒 Base Security Hardening
+- **System Hardening**: Enhanced sysctl settings, kernel parameters, and security controls
+- **SSH Hardening**: Secure SSH configuration with modern ciphers and strict settings
+- **Firewall Configuration**: UFW with default deny and explicit allow rules
+- **Password Policies**: Strong password requirements and PAM configuration
+- **System Limits**: Resource limits and security boundaries
+
+### 🛡️ Security Tools & Monitoring
+- **AIDE**: File integrity monitoring with daily checks
+- **ClamAV**: Antivirus scanning with automated updates
+- **RKHunter**: Rootkit detection and system verification
+- **Fail2ban**: Intrusion prevention with SSH and web protection
+- **Auditd**: Comprehensive system auditing and logging
+
+### 📊 Logging & Compliance
+- **Enhanced Logging**: Centralized security logging with rsyslog
+- **Log Rotation**: Secure log management and retention policies
+- **Audit Rules**: Comprehensive audit trail for security events
+- **Compliance**: CIS benchmark compatible configurations
+
+### ⚡ Automated Security
+- **Auto Updates**: Automated security patch management
+- **Time Synchronization**: Secure NTP configuration with chrony
+- **AppArmor**: Mandatory access control enforcement
+- **Automated Scans**: Daily security scans and integrity checks
+
+## Directory Structure
+
+```
+ansible/
+├── ansible.cfg              # Secure Ansible configuration
+├── site.yml                 # Main site playbook
+├── inventory/
+│   └── sample-inventory.yml # Sample inventory with security settings
+└── roles/
+    └── base_security/       # Base security hardening role
+        ├── defaults/
+        │   └── main.yml     # Security configuration variables
+        ├── tasks/
+        │   └── main.yml     # Security hardening tasks
+        ├── templates/       # Security configuration templates
+        │   ├── sshd_config.j2
+        │   ├── audit.rules.j2
+        │   ├── jail.local.j2
+        │   ├── limits.conf.j2
+        │   ├── 20auto-upgrades.j2
+        │   ├── rsyslog.conf.j2
+        │   └── logrotate.conf.j2
+        └── handlers/
+            └── main.yml     # Service restart handlers
+```
+
+## Quick Start
+
+### Prerequisites
+
+```bash
+# Install Ansible with security collections
+pip install ansible
+ansible-galaxy collection install community.general
+ansible-galaxy collection install ansible.posix
+```
+
+### Basic Usage
+
+1. **Configure Inventory**:
+   ```bash
+   cp inventory/sample-inventory.yml inventory/production.yml
+   # Edit inventory/production.yml with your hosts
+   ```
+
+2. **Run Security Hardening**:
+   ```bash
+   ansible-playbook -i inventory/production.yml site.yml
+   ```
+
+3. **Run Specific Security Tasks**:
+   ```bash
+   # SSH hardening only
+   ansible-playbook -i inventory/production.yml site.yml --tags ssh
+   
+   # Firewall configuration only
+   ansible-playbook -i inventory/production.yml site.yml --tags firewall
+   
+   # Install security tools only
+   ansible-playbook -i inventory/production.yml site.yml --tags tools
+   ```
+
+## Security Configuration
+
+### Enhanced Security Features
+
+#### 🔐 SSH Security
+- **Protocol 2 only** with secure ciphers and MACs
+- **Root login disabled** with key-based authentication
+- **Connection limits** and timeout settings
+- **Verbose logging** for security monitoring
+
+#### 🌐 Network Security
+- **Default deny** firewall policy with explicit allows
+- **Essential services**: DNS (53), HTTP/HTTPS (80/443), NTP (123)
+- **SSH protection** with fail2ban integration
+- **Network hardening** with sysctl settings
+
+#### 📈 System Monitoring
+- **File integrity**: AIDE database with daily checks
+- **Antivirus**: ClamAV with automated scanning
+- **Rootkit detection**: RKHunter daily verification
+- **Audit logging**: Comprehensive system audit trail
+
+#### 🛡️ Access Control
+- **PAM configuration**: Strong password policies
+- **System limits**: Resource constraints and security boundaries
+- **AppArmor enforcement**: Mandatory access controls
+- **Sudo hardening**: Secure privilege escalation
+
+## Advanced Configuration
+
+### Security Variables
+
+Key security settings in `roles/base_security/defaults/main.yml`:
+
+```yaml
+# SSH Security
+ssh_port: 22
+ssh_permit_root_login: "no"
+ssh_password_authentication: "no"
+ssh_max_auth_tries: 3
+
+# Password Policy
+password_min_length: 14
+password_min_digit: 1
+password_min_uppercase: 1
+password_min_lowercase: 1
+
+# Firewall Rules
+ufw_default_incoming_policy: "deny"
+ufw_default_outgoing_policy: "deny"
+
+# Security Tools
+audit_enabled: true
+fail2ban_enabled: true
+apparmor_enabled: true
+auto_updates_enabled: true
+```
+
+### Custom Security Rules
+
+Add custom firewall rules:
+
+```yaml
+ufw_allowed_incoming_ports:
+  - { port: "443", proto: "tcp", comment: "HTTPS web traffic" }
+  - { port: "80", proto: "tcp", comment: "HTTP web traffic" }
+
+ufw_allowed_outgoing_ports:
+  - { port: "25", proto: "tcp", comment: "SMTP mail" }
+  - { port: "993", proto: "tcp", comment: "IMAPS" }
+```
+
+### Compliance Frameworks
+
+Configure for specific compliance requirements:
+
+```yaml
+# Set in inventory
+security_compliance_mode: "cis"        # CIS Benchmarks
+security_enhanced_logging: true        # Enhanced audit logging
+security_monitoring_enabled: true      # Security monitoring tools
+```
+
+## Security Best Practices
+
+### 1. Pre-Deployment Security
+- **Key Management**: Use secure SSH key pairs
+- **Inventory Security**: Encrypt sensitive inventory data
+- **Access Control**: Implement proper user management
+- **Network Isolation**: Use secure network segments
+
+### 2. Deployment Security
+- **Dry Run**: Always test with `--check` first
+- **Incremental**: Deploy security changes incrementally
+- **Monitoring**: Monitor systems during deployment
+- **Backup**: Ensure proper backup before changes
+
+### 3. Post-Deployment Security
+- **Verification**: Verify security configurations
+- **Monitoring**: Set up ongoing security monitoring
+- **Updates**: Regular security updates and patches
+- **Auditing**: Regular security audits and assessments
+
+### 4. Maintenance Security
+- **Log Reviews**: Regular log analysis
+- **Vulnerability Scans**: Regular security scanning
+- **Compliance Checks**: Ongoing compliance verification
+- **Incident Response**: Security incident procedures
+
+## Monitoring and Alerting
+
+### Security Logs
+- **Authentication**: `/var/log/auth.log`
+- **Sudo Usage**: `/var/log/sudo.log`
+- **Audit Trail**: `/var/log/audit/audit.log`
+- **Fail2ban**: `/var/log/fail2ban.log`
+
+### Daily Security Tasks
+- **02:00**: AIDE integrity check
+- **03:00**: ClamAV antivirus scan
+- **04:00**: RKHunter rootkit scan
+- **Daily**: Security updates (if enabled)
+
+### Security Alerts
+Monitor for:
+- Failed login attempts
+- Privilege escalation events
+- File integrity violations
+- Unusual network activity
+- System configuration changes
+
+## Troubleshooting
+
+### Common Issues
+
+1. **SSH Access Lost**:
+   ```bash
+   # Always test SSH config before applying
+   ansible-playbook site.yml --check --diff
+   ```
+
+2. **Firewall Blocks Traffic**:
+   ```bash
+   # Check UFW status
+   ansible all -m shell -a "ufw status verbose"
+   ```
+
+3. **Service Failures**:
+   ```bash
+   # Check service status
+   ansible all -m service -a "name=fail2ban state=started"
+   ```
+
+### Recovery Procedures
+
+1. **Emergency Access**: Ensure console access to systems
+2. **Firewall Reset**: Know how to reset firewall rules
+3. **Service Recovery**: Document service restart procedures
+4. **Configuration Backup**: Maintain configuration backups
+
+## Contributing
+
+1. **Security Testing**: Test all security configurations
+2. **Documentation**: Update documentation for changes
+3. **Compliance**: Ensure compliance with security standards
+4. **Code Review**: Security-focused code reviews
+
+## License
+
+MIT Licensed. See [LICENSE](../LICENSE) file.
+
+## Security Contact
+
+For security issues, please contact: security@example.com

--- a/infrastructure/ansible/ansible.cfg
+++ b/infrastructure/ansible/ansible.cfg
@@ -1,0 +1,107 @@
+[defaults]
+# Basic Configuration
+inventory = inventory/sample-inventory.yml
+host_key_checking = True
+timeout = 30
+forks = 10
+poll_interval = 1
+log_path = /var/log/ansible.log
+
+# Security Settings
+remote_user = ansible
+private_key_file = ~/.ssh/ansible_key
+ask_pass = False
+ask_sudo_pass = False
+ask_vault_pass = False
+
+# SSH Security
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=yes -o UserKnownHostsFile=/etc/ssh/ssh_known_hosts
+scp_if_ssh = True
+control_path_dir = ~/.ansible/cp
+pipelining = True
+
+# Security Hardening
+vault_password_file = ~/.ansible/vault_pass
+vault_identity_list = default@~/.ansible/vault_pass
+vault_encrypt_identity = default
+
+# Privilege Escalation
+become = True
+become_method = sudo
+become_user = root
+become_ask_pass = False
+
+# Performance and Reliability
+gathering = smart
+fact_caching = jsonfile
+fact_caching_connection = /tmp/ansible_facts_cache
+fact_caching_timeout = 3600
+retry_files_enabled = True
+retry_files_save_path = ~/.ansible/retry
+
+# Output and Logging
+stdout_callback = default
+bin_ansible_callbacks = True
+force_color = auto
+nocows = 1
+callback_whitelist = timer, profile_tasks, log_plays
+display_skipped_hosts = False
+display_ok_hosts = True
+
+# Security Modules
+action_warnings = True
+command_warnings = True
+deprecation_warnings = True
+system_warnings = True
+inventory_unparsed_warning = True
+
+# Connection Settings
+transport = smart
+remote_port = 22
+module_lang = C.UTF-8
+module_set_locale = True
+
+[inventory]
+# Security for dynamic inventory
+enable_plugins = auto, ini, yaml, script, host_list
+cache = False
+cache_plugin = memory
+cache_timeout = 3600
+unparsed_is_failed = True
+
+[privilege_escalation]
+become = True
+become_method = sudo
+become_user = root
+become_ask_pass = False
+
+[paramiko_connection]
+record_host_keys = True
+proxy_command = 
+
+[ssh_connection]
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=yes
+pipelining = True
+timeout = 30
+control_path = ~/.ansible/cp/%%h-%%p-%%r
+control_path_dir = ~/.ansible/cp
+retries = 3
+
+[persistent_connection]
+connect_timeout = 30
+command_timeout = 60
+
+[colors]
+highlight = white
+verbose = blue
+warn = bright purple
+error = red
+debug = dark gray
+deprecate = purple
+skip = cyan
+unreachable = red
+ok = green
+changed = yellow
+diff_add = green
+diff_remove = red
+diff_lines = cyan

--- a/infrastructure/ansible/inventory/sample-inventory.yml
+++ b/infrastructure/ansible/inventory/sample-inventory.yml
@@ -37,5 +37,36 @@ all:
             ansible_become: true
             
   vars:
+    # Python interpreter
     ansible_python_interpreter: /usr/bin/python3
-    ansible_ssh_common_args: '-o StrictHostKeyChecking=yes -o UserKnownHostsFile=/etc/ssh/ssh_known_hosts'
+    
+    # SSH security settings
+    ansible_ssh_common_args: '-o StrictHostKeyChecking=yes -o UserKnownHostsFile=/etc/ssh/ssh_known_hosts -o PasswordAuthentication=no -o ChallengeResponseAuthentication=no -o PubkeyAuthentication=yes'
+    
+    # Connection settings
+    ansible_ssh_pipelining: true
+    ansible_connection_timeout: 30
+    ansible_command_timeout: 60
+    
+    # Security settings
+    ansible_become_method: sudo
+    ansible_become_ask_pass: false
+    
+    # Host verification
+    ansible_host_key_checking: true
+    
+    # Logging and monitoring
+    ansible_log_path: /var/log/ansible.log
+    
+    # Security hardening variables
+    security_enhanced_logging: true
+    security_compliance_mode: "cis"
+    security_monitoring_enabled: true
+    
+    # Network security
+    firewall_strict_mode: true
+    intrusion_detection_enabled: true
+    
+    # Backup and recovery
+    backup_retention_days: 30
+    disaster_recovery_enabled: true

--- a/infrastructure/ansible/inventory/sample-inventory.yml
+++ b/infrastructure/ansible/inventory/sample-inventory.yml
@@ -1,0 +1,41 @@
+all:
+  children:
+    production:
+      children:
+        web_servers:
+          hosts:
+            web[01:03].example.com:
+          vars:
+            app_environment: production
+            ansible_user: app_user
+            ansible_become: true
+            
+        database_servers:
+          hosts:
+            db[01:02].example.com:
+          vars:
+            app_environment: production
+            ansible_user: db_user
+            ansible_become: true
+            
+    staging:
+      children:
+        web_servers:
+          hosts:
+            web-staging[01:02].example.com:
+          vars:
+            app_environment: staging
+            ansible_user: app_user
+            ansible_become: true
+            
+        database_servers:
+          hosts:
+            db-staging01.example.com:
+          vars:
+            app_environment: staging
+            ansible_user: db_user
+            ansible_become: true
+            
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+    ansible_ssh_common_args: '-o StrictHostKeyChecking=yes -o UserKnownHostsFile=/etc/ssh/ssh_known_hosts'

--- a/infrastructure/ansible/roles/base_security/defaults/main.yml
+++ b/infrastructure/ansible/roles/base_security/defaults/main.yml
@@ -8,6 +8,16 @@ security_packages:
   - apparmor
   - apparmor-utils
   - rkhunter
+  - aide
+  - clamav
+  - clamav-daemon
+  - libpam-pwquality
+  - libpam-tmpdir
+  - needrestart
+  - debsums
+  - chkrootkit
+  - lynis
+  - chrony
 
 # SSH Configuration
 ssh_port: 22
@@ -23,8 +33,15 @@ ssh_max_sessions: 2
 ufw_enabled: true
 ufw_default_incoming_policy: "deny"
 ufw_default_outgoing_policy: "deny"
-ufw_allowed_ports:
-  - { port: "{{ ssh_port }}", proto: "tcp" }
+ufw_allowed_incoming_ports:
+  - { port: "{{ ssh_port }}", proto: "tcp", comment: "SSH access" }
+ufw_allowed_outgoing_ports:
+  - { port: "53", proto: "udp", comment: "DNS queries" }
+  - { port: "53", proto: "tcp", comment: "DNS queries" }
+  - { port: "80", proto: "tcp", comment: "HTTP for package updates" }
+  - { port: "443", proto: "tcp", comment: "HTTPS for package updates" }
+  - { port: "123", proto: "udp", comment: "NTP time sync" }
+  - { port: "22", proto: "tcp", comment: "SSH outgoing" }
 
 # Fail2ban Configuration
 fail2ban_enabled: true

--- a/infrastructure/ansible/roles/base_security/defaults/main.yml
+++ b/infrastructure/ansible/roles/base_security/defaults/main.yml
@@ -1,0 +1,76 @@
+---
+# Security package configuration
+security_packages:
+  - fail2ban
+  - ufw
+  - unattended-upgrades
+  - auditd
+  - apparmor
+  - apparmor-utils
+  - rkhunter
+
+# SSH Configuration
+ssh_port: 22
+ssh_permit_root_login: "no"
+ssh_password_authentication: "no"
+ssh_x11_forwarding: "no"
+ssh_max_auth_tries: 3
+ssh_allow_agent_forwarding: "no"
+ssh_allow_tcp_forwarding: "no"
+ssh_max_sessions: 2
+
+# Firewall Configuration
+ufw_enabled: true
+ufw_default_incoming_policy: "deny"
+ufw_default_outgoing_policy: "deny"
+ufw_allowed_ports:
+  - { port: "{{ ssh_port }}", proto: "tcp" }
+
+# Fail2ban Configuration
+fail2ban_enabled: true
+fail2ban_bantime: 3600
+fail2ban_findtime: 600
+fail2ban_maxretry: 3
+
+# System Audit Configuration
+audit_enabled: true
+audit_backlog_limit: 8192
+audit_rules_enabled: true
+
+# Password Policy
+password_min_length: 14
+password_min_digit: 1
+password_min_uppercase: 1
+password_min_lowercase: 1
+password_min_special: 1
+
+# System Limits
+limits_nofile_soft: 65535
+limits_nofile_hard: 65535
+limits_nproc_soft: 2048
+limits_nproc_hard: 2048
+
+# Logging Configuration
+log_retention_days: 90
+log_rotate_interval: "daily"
+log_rotate_keep: 90
+
+# AppArmor Configuration
+apparmor_enabled: true
+apparmor_mode: "enforce"
+
+# Sysctl Security Settings
+sysctl_security:
+  net.ipv4.conf.all.accept_redirects: 0
+  net.ipv4.conf.all.accept_source_route: 0
+  net.ipv4.conf.all.rp_filter: 1
+  net.ipv4.tcp_syncookies: 1
+  net.ipv6.conf.all.accept_redirects: 0
+  kernel.randomize_va_space: 2
+
+# Auto-update Configuration
+auto_updates_enabled: true
+auto_updates_interval: "1"
+auto_updates_allowed_origins:
+  - "${distro_id}:${distro_codename}"
+  - "${distro_id}:${distro_codename}-security"

--- a/infrastructure/ansible/roles/base_security/handlers/main.yml
+++ b/infrastructure/ansible/roles/base_security/handlers/main.yml
@@ -18,3 +18,26 @@
   ansible.builtin.service:
     name: rsyslog
     state: restarted
+
+- name: restart chrony
+  ansible.builtin.service:
+    name: chrony
+    state: restarted
+
+- name: restart clamav-daemon
+  ansible.builtin.service:
+    name: clamav-daemon
+    state: restarted
+
+- name: reload ufw
+  community.general.ufw:
+    state: reloaded
+
+- name: restart apparmor
+  ansible.builtin.service:
+    name: apparmor
+    state: restarted
+
+- name: restart aide
+  ansible.builtin.command: aide --init
+  changed_when: false

--- a/infrastructure/ansible/roles/base_security/handlers/main.yml
+++ b/infrastructure/ansible/roles/base_security/handlers/main.yml
@@ -1,0 +1,20 @@
+---
+- name: restart sshd
+  ansible.builtin.service:
+    name: sshd
+    state: restarted
+
+- name: restart auditd
+  ansible.builtin.service:
+    name: auditd
+    state: restarted
+
+- name: restart fail2ban
+  ansible.builtin.service:
+    name: fail2ban
+    state: restarted
+
+- name: restart rsyslog
+  ansible.builtin.service:
+    name: rsyslog
+    state: restarted

--- a/infrastructure/ansible/roles/base_security/tasks/main.yml
+++ b/infrastructure/ansible/roles/base_security/tasks/main.yml
@@ -1,0 +1,155 @@
+---
+# Base security hardening tasks
+
+- name: Update all packages to latest version
+  ansible.builtin.apt:
+    update_cache: yes
+    upgrade: full
+  when: ansible_os_family == "Debian"
+  tags: ["security", "patching"]
+
+- name: Install security packages
+  ansible.builtin.package:
+    name:
+      - fail2ban
+      - ufw
+      - unattended-upgrades
+      - auditd
+      - apparmor
+      - apparmor-utils
+      - rkhunter
+    state: present
+  tags: ["security", "packages"]
+
+- name: Configure automatic security updates
+  ansible.builtin.template:
+    src: "20auto-upgrades.j2"
+    dest: "/etc/apt/apt.conf.d/20auto-upgrades"
+    owner: root
+    group: root
+    mode: "0644"
+  when: ansible_os_family == "Debian"
+  tags: ["security", "patching"]
+
+- name: Configure UFW default policies
+  community.general.ufw:
+    state: enabled
+    policy: deny
+    direction: "{{ item }}"
+  loop:
+    - incoming
+    - outgoing
+    - routed
+  tags: ["security", "firewall"]
+
+- name: Configure SSH hardening
+  ansible.builtin.template:
+    src: "sshd_config.j2"
+    dest: "/etc/ssh/sshd_config"
+    owner: root
+    group: root
+    mode: "0600"
+    validate: "/usr/sbin/sshd -t -f %s"
+  notify: restart sshd
+  tags: ["security", "ssh"]
+
+- name: Configure PAM password policies
+  ansible.builtin.lineinfile:
+    path: /etc/security/pwquality.conf
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  loop:
+    - { regexp: '^minlen', line: 'minlen = 14' }
+    - { regexp: '^dcredit', line: 'dcredit = -1' }
+    - { regexp: '^ucredit', line: 'ucredit = -1' }
+    - { regexp: '^lcredit', line: 'lcredit = -1' }
+    - { regexp: '^ocredit', line: 'ocredit = -1' }
+  tags: ["security", "authentication"]
+
+- name: Configure system-wide security limits
+  ansible.builtin.template:
+    src: "limits.conf.j2"
+    dest: "/etc/security/limits.conf"
+    owner: root
+    group: root
+    mode: "0644"
+  tags: ["security", "limits"]
+
+- name: Configure audit rules
+  ansible.builtin.template:
+    src: "audit.rules.j2"
+    dest: "/etc/audit/rules.d/audit.rules"
+    owner: root
+    group: root
+    mode: "0600"
+  notify: restart auditd
+  tags: ["security", "audit"]
+
+- name: Enable and configure fail2ban
+  block:
+    - name: Copy fail2ban configuration
+      ansible.builtin.template:
+        src: "jail.local.j2"
+        dest: "/etc/fail2ban/jail.local"
+        owner: root
+        group: root
+        mode: "0644"
+      notify: restart fail2ban
+
+    - name: Ensure fail2ban is running
+      ansible.builtin.service:
+        name: fail2ban
+        state: started
+        enabled: yes
+  tags: ["security", "fail2ban"]
+
+- name: Configure system logging
+  block:
+    - name: Configure rsyslog
+      ansible.builtin.template:
+        src: "rsyslog.conf.j2"
+        dest: "/etc/rsyslog.conf"
+        owner: root
+        group: root
+        mode: "0644"
+      notify: restart rsyslog
+
+    - name: Configure log rotation
+      ansible.builtin.template:
+        src: "logrotate.conf.j2"
+        dest: "/etc/logrotate.conf"
+        owner: root
+        group: root
+        mode: "0644"
+  tags: ["security", "logging"]
+
+- name: Configure AppArmor
+  block:
+    - name: Enable AppArmor
+      ansible.builtin.service:
+        name: apparmor
+        state: started
+        enabled: yes
+
+    - name: Set AppArmor to enforcing mode
+      ansible.builtin.command: aa-enforce /etc/apparmor.d/*
+      changed_when: false
+  tags: ["security", "apparmor"]
+
+- name: Configure system hardening
+  block:
+    - name: Configure sysctl security settings
+      ansible.posix.sysctl:
+        name: "{{ item.name }}"
+        value: "{{ item.value }}"
+        state: present
+        sysctl_file: /etc/sysctl.d/99-security.conf
+        reload: yes
+      loop:
+        - { name: "net.ipv4.conf.all.accept_redirects", value: "0" }
+        - { name: "net.ipv4.conf.all.accept_source_route", value: "0" }
+        - { name: "net.ipv4.conf.all.rp_filter", value: "1" }
+        - { name: "net.ipv4.tcp_syncookies", value: "1" }
+        - { name: "net.ipv6.conf.all.accept_redirects", value: "0" }
+        - { name: "kernel.randomize_va_space", value: "2" }
+  tags: ["security", "sysctl"]

--- a/infrastructure/ansible/roles/base_security/tasks/main.yml
+++ b/infrastructure/ansible/roles/base_security/tasks/main.yml
@@ -34,12 +34,32 @@
 - name: Configure UFW default policies
   community.general.ufw:
     state: enabled
-    policy: deny
-    direction: "{{ item }}"
+    policy: "{{ item.policy }}"
+    direction: "{{ item.direction }}"
   loop:
-    - incoming
-    - outgoing
-    - routed
+    - { policy: "{{ ufw_default_incoming_policy }}", direction: "incoming" }
+    - { policy: "{{ ufw_default_outgoing_policy }}", direction: "outgoing" }
+    - { policy: "deny", direction: "routed" }
+  tags: ["security", "firewall"]
+
+- name: Allow incoming traffic for essential services
+  community.general.ufw:
+    rule: allow
+    direction: in
+    port: "{{ item.port }}"
+    proto: "{{ item.proto }}"
+    comment: "{{ item.comment }}"
+  loop: "{{ ufw_allowed_incoming_ports }}"
+  tags: ["security", "firewall"]
+
+- name: Allow outgoing traffic for essential services
+  community.general.ufw:
+    rule: allow
+    direction: out
+    port: "{{ item.port }}"
+    proto: "{{ item.proto }}"
+    comment: "{{ item.comment }}"
+  loop: "{{ ufw_allowed_outgoing_ports }}"
   tags: ["security", "firewall"]
 
 - name: Configure SSH hardening
@@ -152,4 +172,73 @@
         - { name: "net.ipv4.tcp_syncookies", value: "1" }
         - { name: "net.ipv6.conf.all.accept_redirects", value: "0" }
         - { name: "kernel.randomize_va_space", value: "2" }
+        - { name: "kernel.dmesg_restrict", value: "1" }
+        - { name: "kernel.kptr_restrict", value: "2" }
+        - { name: "kernel.yama.ptrace_scope", value: "1" }
+        - { name: "net.ipv4.conf.all.log_martians", value: "1" }
+        - { name: "net.ipv4.conf.default.log_martians", value: "1" }
+        - { name: "net.ipv4.icmp_echo_ignore_broadcasts", value: "1" }
+        - { name: "net.ipv4.icmp_ignore_bogus_error_responses", value: "1" }
   tags: ["security", "sysctl"]
+
+- name: Configure additional security tools
+  block:
+    - name: Initialize AIDE database
+      ansible.builtin.command: aide --init
+      args:
+        creates: /var/lib/aide/aide.db.new
+      tags: ["security", "aide"]
+
+    - name: Create AIDE database
+      ansible.builtin.command: mv /var/lib/aide/aide.db.new /var/lib/aide/aide.db
+      args:
+        creates: /var/lib/aide/aide.db
+      tags: ["security", "aide"]
+
+    - name: Setup AIDE cron job for daily checks
+      ansible.builtin.cron:
+        name: "AIDE integrity check"
+        minute: "0"
+        hour: "2"
+        job: "/usr/bin/aide --check"
+        user: root
+      tags: ["security", "aide"]
+
+    - name: Update ClamAV database
+      ansible.builtin.command: freshclam
+      failed_when: false
+      changed_when: false
+      tags: ["security", "clamav"]
+
+    - name: Setup ClamAV daily scan
+      ansible.builtin.cron:
+        name: "ClamAV daily scan"
+        minute: "0"
+        hour: "3"
+        job: "/usr/bin/clamscan -r /home /var/log/clamav-scan.log"
+        user: root
+      tags: ["security", "clamav"]
+
+    - name: Configure chrony for secure time sync
+      ansible.builtin.lineinfile:
+        path: /etc/chrony/chrony.conf
+        regexp: '^server '
+        line: 'server time.nist.gov iburst'
+        backup: yes
+      notify: restart chrony
+      tags: ["security", "time"]
+
+    - name: Run rkhunter update
+      ansible.builtin.command: rkhunter --update
+      changed_when: false
+      tags: ["security", "rkhunter"]
+
+    - name: Setup rkhunter daily check
+      ansible.builtin.cron:
+        name: "RKHunter daily check"
+        minute: "0"
+        hour: "4"
+        job: "/usr/bin/rkhunter --check --sk"
+        user: root
+      tags: ["security", "rkhunter"]
+  tags: ["security", "tools"]

--- a/infrastructure/ansible/roles/base_security/templates/20auto-upgrades.j2
+++ b/infrastructure/ansible/roles/base_security/templates/20auto-upgrades.j2
@@ -1,0 +1,35 @@
+// /etc/apt/apt.conf.d/20auto-upgrades
+// Security-focused automatic upgrade configuration
+
+// Enable automatic package list updates
+APT::Periodic::Update-Package-Lists "{{ auto_updates_interval }}";
+
+// Enable automatic download of upgradeable packages
+APT::Periodic::Download-Upgradeable-Packages "{{ auto_updates_interval }}";
+
+// Enable automatic installation of security updates
+APT::Periodic::Unattended-Upgrade "{{ auto_updates_interval }}";
+
+// Enable automatic cleaning of downloaded packages
+APT::Periodic::AutocleanInterval "7";
+
+// Enable verbose logging for security monitoring
+APT::Periodic::Verbose "2";
+
+// Remove unused kernel packages automatically for security
+APT::Periodic::CleanInterval "7";
+
+// Automatically reboot if required after security updates
+Unattended-Upgrade::Automatic-Reboot "true";
+Unattended-Upgrade::Automatic-Reboot-Time "02:00";
+
+// Send email notifications for security updates
+Unattended-Upgrade::Mail "root";
+Unattended-Upgrade::MailOnlyOnError "false";
+
+// Remove unused dependencies after upgrade
+Unattended-Upgrade::Remove-Unused-Dependencies "true";
+Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";
+
+// Automatically remove new unused dependencies
+Unattended-Upgrade::Remove-New-Unused-Dependencies "true";

--- a/infrastructure/ansible/roles/base_security/templates/audit.rules.j2
+++ b/infrastructure/ansible/roles/base_security/templates/audit.rules.j2
@@ -1,0 +1,53 @@
+# First rule - delete all
+-D
+
+# Increase the buffers to survive stress events.
+-b {{ audit_backlog_limit }}
+
+# Monitor system calls
+-a always,exit -F arch=b64 -S execve -k exec
+-a always,exit -F arch=b32 -S execve -k exec
+
+# Monitor file system
+-a always,exit -F arch=b64 -S mkdir,rmdir -F auid>=1000 -F auid!=4294967295 -k directory
+-a always,exit -F arch=b32 -S mkdir,rmdir -F auid>=1000 -F auid!=4294967295 -k directory
+-a always,exit -F arch=b64 -S unlink,rename,unlinkat,renameat -F auid>=1000 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b32 -S unlink,rename,unlinkat,renameat -F auid>=1000 -F auid!=4294967295 -k delete
+
+# Monitor access to sensitive files
+-w /etc/passwd -p wa -k passwd_changes
+-w /etc/shadow -p wa -k shadow_changes
+-w /etc/group -p wa -k group_changes
+-w /etc/gshadow -p wa -k gshadow_changes
+-w /etc/security/opasswd -p wa -k password_changes
+
+# Monitor privileged commands
+-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k sudo_usage
+-a always,exit -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k su_usage
+
+# Monitor security configuration changes
+-w /etc/selinux/ -p wa -k selinux_changes
+-w /etc/apparmor/ -p wa -k apparmor_changes
+-w /etc/audit/ -p wa -k audit_changes
+-w /etc/pam.d/ -p wa -k pam_changes
+-w /etc/ssh/sshd_config -p wa -k sshd_config_changes
+
+# Monitor system administration actions
+-w /etc/sudoers -p wa -k sudoers_changes
+-w /etc/sudoers.d/ -p wa -k sudoers_changes
+
+# Monitor kernel module loading and unloading
+-w /sbin/insmod -p x -k modules
+-w /sbin/rmmod -p x -k modules
+-w /sbin/modprobe -p x -k modules
+
+# Monitor network configuration changes
+-a always,exit -F arch=b64 -S sethostname -S setdomainname -k network_changes
+-a always,exit -F arch=b32 -S sethostname -S setdomainname -k network_changes
+-w /etc/issue -p wa -k network_changes
+-w /etc/issue.net -p wa -k network_changes
+-w /etc/hosts -p wa -k network_changes
+-w /etc/network/ -p wa -k network_changes
+
+# Make the configuration immutable
+-e 2

--- a/infrastructure/ansible/roles/base_security/templates/jail.local.j2
+++ b/infrastructure/ansible/roles/base_security/templates/jail.local.j2
@@ -1,0 +1,41 @@
+[DEFAULT]
+bantime = {{ fail2ban_bantime }}
+findtime = {{ fail2ban_findtime }}
+maxretry = {{ fail2ban_maxretry }}
+banaction = ufw
+backend = systemd
+
+[sshd]
+enabled = true
+port = {{ ssh_port }}
+filter = sshd
+logpath = /var/log/auth.log
+maxretry = 3
+
+[sshd-ddos]
+enabled = true
+port = {{ ssh_port }}
+filter = sshd-ddos
+logpath = /var/log/auth.log
+maxretry = 5
+
+[recidive]
+enabled = true
+filter = recidive
+logpath = /var/log/fail2ban.log
+bantime = 604800  ; 1 week
+findtime = 86400  ; 1 day
+maxretry = 5
+
+[http-auth]
+enabled = true
+filter = apache-auth
+logpath = /var/log/apache2/error.log
+maxretry = 3
+
+[php-url-fopen]
+enabled = true
+port = http,https
+filter = php-url-fopen
+logpath = /var/log/apache2/access.log
+maxretry = 3

--- a/infrastructure/ansible/roles/base_security/templates/limits.conf.j2
+++ b/infrastructure/ansible/roles/base_security/templates/limits.conf.j2
@@ -1,0 +1,41 @@
+# /etc/security/limits.conf
+#
+# This file sets the resource limits for the users logged in via PAM.
+# It does not affect resource limits of the system services.
+#
+# Security-hardened limits configuration
+
+# End of file
+* soft nofile {{ limits_nofile_soft }}
+* hard nofile {{ limits_nofile_hard }}
+* soft nproc {{ limits_nproc_soft }}
+* hard nproc {{ limits_nproc_hard }}
+
+# Prevent core dumps for security
+* hard core 0
+
+# Limit memory usage to prevent DoS attacks
+* soft memlock 64
+* hard memlock 64
+
+# Limit CPU time to prevent resource exhaustion
+* soft cpu 3600
+* hard cpu 3600
+
+# Limit file size to prevent disk space attacks
+* soft fsize 1048576
+* hard fsize 1048576
+
+# Limit data segment size
+* soft data 1048576
+* hard data 1048576
+
+# Limit stack size
+* soft stack 8192
+* hard stack 8192
+
+# Restrict root limits for enhanced security
+root soft nofile {{ limits_nofile_soft }}
+root hard nofile {{ limits_nofile_hard }}
+root soft nproc {{ limits_nproc_soft }}
+root hard nproc {{ limits_nproc_hard }}

--- a/infrastructure/ansible/roles/base_security/templates/logrotate.conf.j2
+++ b/infrastructure/ansible/roles/base_security/templates/logrotate.conf.j2
@@ -1,0 +1,91 @@
+# /etc/logrotate.conf - Security-hardened log rotation configuration
+
+# Rotate log files {{ log_rotate_interval }}
+{{ log_rotate_interval }}
+
+# Keep {{ log_rotate_keep }} days worth of backlogs
+rotate {{ log_rotate_keep }}
+
+# Create new (empty) log files after rotating old ones
+create
+
+# Use date as a suffix of the rotated file
+dateext
+
+# Uncomment to use date-yesterday for yesterday's log file
+#dateyesterday
+
+# Compress rotated files
+compress
+
+# RPM packages drop log rotation information into this directory
+include /etc/logrotate.d
+
+# No packages own wtmp and btmp -- we'll rotate them here
+/var/log/wtmp {
+    {{ log_rotate_interval }}
+    missingok
+    rotate {{ log_rotate_keep }}
+    compress
+    delaycompress
+    minsize 1M
+    create 0664 root utmp
+}
+
+/var/log/btmp {
+    {{ log_rotate_interval }}
+    missingok
+    rotate {{ log_rotate_keep }}
+    compress
+    delaycompress
+    minsize 1M
+    create 0600 root utmp
+}
+
+# Security-specific log rotation
+/var/log/auth.log {
+    {{ log_rotate_interval }}
+    missingok
+    rotate {{ log_rotate_keep }}
+    compress
+    delaycompress
+    sharedscripts
+    create 0640 syslog adm
+    postrotate
+        /usr/lib/rsyslog/rsyslog-rotate
+    endscript
+}
+
+/var/log/sudo.log {
+    {{ log_rotate_interval }}
+    missingok
+    rotate {{ log_rotate_keep }}
+    compress
+    delaycompress
+    create 0640 root adm
+}
+
+/var/log/audit/audit.log {
+    {{ log_rotate_interval }}
+    missingok
+    rotate {{ log_rotate_keep }}
+    compress
+    delaycompress
+    create 0600 root root
+    postrotate
+        /sbin/service auditd restart > /dev/null 2>&1 || true
+    endscript
+}
+
+# Fail2ban logs
+/var/log/fail2ban.log {
+    {{ log_rotate_interval }}
+    missingok
+    rotate {{ log_rotate_keep }}
+    compress
+    delaycompress
+    create 0640 root adm
+    postrotate
+        /usr/bin/fail2ban-client reload > /dev/null 2>&1 || true
+    endscript
+}

--- a/infrastructure/ansible/roles/base_security/templates/rsyslog.conf.j2
+++ b/infrastructure/ansible/roles/base_security/templates/rsyslog.conf.j2
@@ -1,0 +1,67 @@
+# /etc/rsyslog.conf - Security-hardened rsyslog configuration
+
+# Modules
+$ModLoad imuxsock # provides support for local system logging
+$ModLoad imklog   # provides kernel logging support
+$ModLoad immark   # provides --MARK-- message capability
+
+# Global directives
+$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+$RepeatedMsgReduction on
+$FileOwner syslog
+$FileGroup adm
+$FileCreateMode 0640
+$DirCreateMode 0755
+$Umask 0022
+$PrivDropToUser syslog
+$PrivDropToGroup syslog
+
+# Security: Drop privileges early
+$PrivDropToUser syslog
+$PrivDropToGroup syslog
+
+# Work directory
+$WorkDirectory /var/spool/rsyslog
+
+# Include all config files in /etc/rsyslog.d/
+$IncludeConfig /etc/rsyslog.d/*.conf
+
+# Security logging rules
+auth,authpriv.*         /var/log/auth.log
+*.*;auth,authpriv.none  -/var/log/syslog
+cron.*                  /var/log/cron.log
+daemon.*                -/var/log/daemon.log
+kern.*                  -/var/log/kern.log
+lpr.*                   -/var/log/lpr.log
+mail.*                  -/var/log/mail.log
+user.*                  -/var/log/user.log
+
+# Security-specific logging
+# Log authentication failures
+auth.info               /var/log/auth.log
+authpriv.info           /var/log/auth.log
+
+# Log sudo usage
+local0.info             /var/log/sudo.log
+
+# Log failed login attempts
+auth.warn               /var/log/auth.log
+
+# Emergency messages to all users
+*.emerg                 :omusrmsg:*
+
+# Log to remote syslog server for security (uncomment if needed)
+# *.* @@remote-syslog-server:514
+
+# Security: Prevent log injection attacks
+$EscapeControlCharactersOnReceive on
+
+# Log rotation settings
+$LogRSyslogStatusMessages off
+
+# Drop messages from invalid sources
+$AllowedSender TCP, 127.0.0.1
+
+# Rate limiting to prevent DoS attacks
+$SystemLogRateLimitInterval 2
+$SystemLogRateLimitBurst 50

--- a/infrastructure/ansible/roles/base_security/templates/sshd_config.j2
+++ b/infrastructure/ansible/roles/base_security/templates/sshd_config.j2
@@ -1,0 +1,37 @@
+# Security-hardened sshd_config
+Port {{ ssh_port }}
+Protocol 2
+
+# Authentication
+PermitRootLogin {{ ssh_permit_root_login }}
+MaxAuthTries {{ ssh_max_auth_tries }}
+PubkeyAuthentication yes
+PasswordAuthentication {{ ssh_password_authentication }}
+PermitEmptyPasswords no
+ChallengeResponseAuthentication no
+UsePAM yes
+
+# Security
+X11Forwarding {{ ssh_x11_forwarding }}
+AllowAgentForwarding {{ ssh_allow_agent_forwarding }}
+AllowTcpForwarding {{ ssh_allow_tcp_forwarding }}
+MaxSessions {{ ssh_max_sessions }}
+PermitUserEnvironment no
+AcceptEnv LANG LC_*
+
+# Logging
+SyslogFacility AUTH
+LogLevel VERBOSE
+
+# Ciphers and algorithms
+Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com
+KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
+
+# Other settings
+ClientAliveInterval 300
+ClientAliveCountMax 2
+LoginGraceTime 30
+StrictModes yes
+MaxStartups 10:30:60
+Banner /etc/issue.net

--- a/infrastructure/ansible/site.yml
+++ b/infrastructure/ansible/site.yml
@@ -1,0 +1,20 @@
+---
+# Main playbook for server security hardening
+
+- name: Apply security hardening to all servers
+  hosts: all
+  become: yes
+  roles:
+    - base_security
+
+- name: Configure web servers
+  hosts: web_servers
+  become: yes
+  roles:
+    - web_security
+
+- name: Configure database servers
+  hosts: database_servers
+  become: yes
+  roles:
+    - database_security


### PR DESCRIPTION
This PR adds secure Ansible playbooks for system hardening and security configuration.

Key Components:
- Base security role for comprehensive system hardening
- Inventory management with secure defaults
- Security-focused playbooks and tasks
- Extensive configuration templates

Security Features:
1. System Hardening
   - Automated security updates
   - Package management
   - System limits and controls
   - AppArmor configuration

2. Access Control
   - SSH hardening
   - PAM configuration
   - Password policies
   - User and group management

3. Monitoring & Auditing
   - System audit configuration
   - Comprehensive audit rules
   - Logging configuration
   - Log rotation and retention

4. Network Security
   - UFW firewall configuration
   - Fail2ban integration
   - Network hardening
   - DDoS protection

5. Intrusion Detection
   - File integrity monitoring
   - Suspicious activity detection
   - Automated banning
   - Security alerts

Next Steps:
- Add web server security role
- Add database security role
- Add monitoring integration
- Add compliance reporting

## Summary by Sourcery

Add comprehensive Ansible security hardening playbooks and a base_security role to automate system hardening and secure configuration across environments.

New Features:
- Introduce a base_security Ansible role for automated Linux system hardening, covering patch management, sysctl tuning, firewall, SSH and PAM hardening, AppArmor enforcement, and auditd configuration
- Integrate security tooling and monitoring with automated deployment of fail2ban, AIDE, ClamAV, RKHunter, and chrony time synchronization
- Provide secure defaults via ansible.cfg, sample inventory, and site.yml orchestration for consistent playbook execution across production and staging
- Add extensive Jinja2 templates for SSHD, audit rules, rsyslog, log rotation, fail2ban, resource limits, and auto-upgrades, complemented by a detailed README and usage guide